### PR TITLE
Better selection click detection

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -530,21 +530,26 @@ class App extends React.Component<{}, AppState> {
               let isDraggingElements = false;
               const cursorStyle = document.documentElement.style.cursor;
               if (this.state.elementType === "selection") {
-                const selectedElement = elements.find(element => {
-                  const isSelected = hitTest(element, x, y);
-                  if (isSelected) {
-                    element.isSelected = true;
-                  }
-                  return isSelected;
+                const hitElement = elements.find(element => {
+                  return hitTest(element, x, y);
                 });
 
-                // deselect everything except target element to-be-selected
-                elements.forEach(element => {
-                  if (element === selectedElement) return;
-                  element.isSelected = false;
-                });
-                if (selectedElement) {
-                  this.setState({ draggingElement: selectedElement });
+                // If we click on something
+                if (hitElement) {
+                  if (hitElement.isSelected) {
+                    // If that element is not already selected, do nothing,
+                    // we're likely going to drag it
+                  } else {
+                    // We unselect every other elements unless shift is pressed
+                    if (!e.shiftKey) {
+                      clearSelection();
+                    }
+                    // No matter what, we select it
+                    hitElement.isSelected = true;
+                  }
+                } else {
+                  // If we don't click on anything, let's remove all the selected elements
+                  clearSelection();
                 }
 
                 isDraggingElements = elements.some(


### PR DESCRIPTION
There's been a few commits that touched this but the behavior was still weird. I think that it is now good.

If you have elements already selected:
-  you click on one of them, it does nothing. It will let you drag the entire pack.
- you click on an unselected one, it selects it and unless shift is pressed, unselect everything else. This way you can select a new element.
- you click somewhere outside of elements, it unselects everything so you can start a new selection.

![ezgif-1-1ce6f6b38698](https://user-images.githubusercontent.com/197597/71697264-57254680-2d6c-11ea-95be-1b9a18e8e952.gif)
